### PR TITLE
Bring minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Binary
+hello-world
+
+# Objects
+*.[o]

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,23 @@
-PREFIX=/usr/local
-CC=cc
-CFLAGS=-Wall -Wextra -Werror -std=c99 -O3
+PREFIX := /usr/local
+CC := cc
 
-OUT=hello-world
+CFLAGS := -Wall -Wextra -Werror
+CFLAGS += -pedantic -std=c99 -O3
 
-SRCS=main.c
-OBJS=main.o
+OUT := hello-world
+
+SRC := main.c
+OBJ := $(SRC:.c=.o)
 
 all: $(OUT)
 
-$(OBJS): $(SRCS)
-	$(CC) -c -o $@ $< $(CFLAGS)
-
-$(OUT): $(OBJS)
-	$(CC) -g -o $@ $<
+$(OUT): $(OBJ)
+	$(CC) -o $@ $< $(CFLAGS)
 
 install: $(OUT)
 	install -m 0755	$(OUT) $(PREFIX)/bin
 
 clean:
-	$(RM) $(OBJS) $(OUT)
+	$(RM) $(OBJ) $(OUT)
 
-.PHONY: install clean
+.PHONY: install clean all

--- a/main.c
+++ b/main.c
@@ -1,6 +1,11 @@
-#include <stdio.h>
+#include <unistd.h>
 
-int main() {
-    printf("Hello World!\n");
-    return 0;
+#define GREETING ("Hello World!\n")
+#define GREETING_SIZE (sizeof (GREETING) - 1)
+
+int main(void)
+{
+    ssize_t written = write(STDOUT_FILENO, GREETING, GREETING_SIZE);
+
+    return (written == GREETING_SIZE);
 }


### PR DESCRIPTION
> main.c
- Use `write` instead of `printf` with exact string length
- Return based on write success

> Makefile
- Use builtin `.c.o` Makefile pattern
- Add `-pedantic` in CFLAGS
- Remove `-g` flag (debug is in contradiction with O3)
- Use non recursive variables

> Other
- Add gitignore